### PR TITLE
Don't treat `-` as a word character

### DIFF
--- a/languages/scss/config.toml
+++ b/languages/scss/config.toml
@@ -16,5 +16,4 @@ brackets = [
         "comment",
     ] },
 ]
-word_characters = ["-"]
 prettier_parser_name = "scss"


### PR DESCRIPTION
This PR removes `-` as a word character.

Since CSS uses `-` as a common separator between words in selectors, it shouldn't be used as a word character, as this means you can only select the _entire_ selector with the cursor instead of individual words.

### Before

https://github.com/user-attachments/assets/7ec3819e-30d2-47a5-8557-73f68294f0ac

### After

https://github.com/user-attachments/assets/e46b6a94-0b56-45c9-b286-5c1136a1686e

This matches the behavior we're now using for plain CSS: https://github.com/zed-industries/zed/pull/17084.