### PR TITLE
Revert "Don't treat `-` as a word character"

### DIFF
--- a/languages/scss/config.toml
+++ b/languages/scss/config.toml
@@ -16,4 +16,5 @@ brackets = [
         "comment",
     ] },
 ]
+word_characters = ["-"]
 prettier_parser_name = "scss"


### PR DESCRIPTION
This PR reverts #9.

While it's true that we don't want to treat `-` as a word character for the purposes of selections, we're actually fixing this within Zed itself: https://github.com/zed-industries/zed/pull/17171

So we can leave `-` as a word character for the purposes of the SCSS language.

Apologies for the churn 😄 

This reverts commit 755fccd4d41463b3fb16900617333d4faf827e72.