### PR TITLE
Add workaround for leading / on windows paths

### DIFF
--- a/src/language_servers/scss_lsp.rs
+++ b/src/language_servers/scss_lsp.rs
@@ -2,6 +2,8 @@ use std::{env, fs};
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
+use crate::zed_ext;
+
 const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-css-language-server";
 const PACKAGE_NAME: &str = "vscode-langservers-extracted";
@@ -36,8 +38,7 @@ impl SCSSLsp {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),

--- a/src/language_servers/some_sass.rs
+++ b/src/language_servers/some_sass.rs
@@ -2,6 +2,8 @@ use std::{env, fs};
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
+use crate::zed_ext;
+
 const SERVER_PATH: &str = "node_modules/some-sass-language-server/bin/some-sass-language-server";
 const PACKAGE_NAME: &str = "some-sass-language-server";
 
@@ -35,8 +37,7 @@ impl SomeSass {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),

--- a/src/scss.rs
+++ b/src/scss.rs
@@ -36,3 +36,25 @@ impl zed::Extension for SCSSExtension {
     }
 }
 zed::register_extension!(SCSSExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a workaround for the leading / on Windows paths (https://github.com/zed-industries/zed/issues/20559) and based on https://github.com/zed-extensions/astro/pull/5.

Credits to @maxdeviant for the original fix.