### PR TITLE
Bump extension API, remove windows path workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "zed_scss"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/scss.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.7.0"

--- a/src/language_servers/scss_lsp.rs
+++ b/src/language_servers/scss_lsp.rs
@@ -2,8 +2,6 @@ use std::{env, fs};
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
-use crate::zed_ext;
-
 const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-css-language-server";
 const PACKAGE_NAME: &str = "vscode-langservers-extracted";
@@ -38,7 +36,8 @@ impl SCSSLsp {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+                env::current_dir()
+                    .unwrap()
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),

--- a/src/language_servers/some_sass.rs
+++ b/src/language_servers/some_sass.rs
@@ -2,8 +2,6 @@ use std::{env, fs};
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
-use crate::zed_ext;
-
 const SERVER_PATH: &str = "node_modules/some-sass-language-server/bin/some-sass-language-server";
 const PACKAGE_NAME: &str = "some-sass-language-server";
 
@@ -37,7 +35,8 @@ impl SomeSass {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+                env::current_dir()
+                    .unwrap()
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),

--- a/src/scss.rs
+++ b/src/scss.rs
@@ -36,25 +36,3 @@ impl zed::Extension for SCSSExtension {
     }
 }
 zed::register_extension!(SCSSExtension);
-
-/// Extensions to the Zed extension API that have not yet stabilized.
-mod zed_ext {
-    /// Sanitizes the given path to remove the leading `/` on Windows.
-    ///
-    /// On macOS and Linux this is a no-op.
-    ///
-    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
-    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
-        use zed_extension_api::{current_platform, Os};
-
-        let (os, _arch) = current_platform();
-        match os {
-            Os::Mac | Os::Linux => path,
-            Os::Windows => path
-                .to_string_lossy()
-                .to_string()
-                .trim_start_matches('/')
-                .into(),
-        }
-    }
-}


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️

See https://github.com/zed-industries/zed/pull/37811

This PR bumps the zed extension API to the latest version, which removes the need to work around a bug where current_dir() returned an invalid path on windows.