### PR TITLE
Add lsp configuration support

### DIFF
--- a/src/language_servers/some_sass.rs
+++ b/src/language_servers/some_sass.rs
@@ -1,6 +1,6 @@
 use std::{env, fs};
 
-use zed_extension_api::{self as zed, LanguageServerId, Result};
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
 
 const SERVER_PATH: &str = "node_modules/some-sass-language-server/bin/some-sass-language-server";
 const PACKAGE_NAME: &str = "some-sass-language-server";
@@ -88,5 +88,31 @@ impl SomeSass {
 
         self.did_find_server = true;
         Ok(SERVER_PATH.to_string())
+    }
+
+    pub fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let options = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options);
+        Ok(options)
+    }
+
+    pub fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        if let Ok(Some(settings)) = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .map(|lsp_settings| lsp_settings.settings)
+        {
+            Ok(Some(settings))
+        } else {
+            self.language_server_initialization_options(language_server_id, worktree)
+                .map(|init_options| init_options.and_then(|opts| opts.get("settings").cloned()))
+        }
     }
 }

--- a/src/scss.rs
+++ b/src/scss.rs
@@ -34,5 +34,41 @@ impl zed::Extension for SCSSExtension {
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }
     }
+
+    fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        match language_server_id.as_ref() {
+            SomeSass::LANGUAGE_SERVER_ID => {
+                let some_sass = self.some_sass.get_or_insert_with(|| SomeSass::new());
+                some_sass.language_server_initialization_options(language_server_id, worktree)
+            }
+            SCSSLsp::LANGUAGE_SERVER_ID => {
+                let scss_lsp = self.scss_lsp.get_or_insert_with(|| SCSSLsp::new());
+                scss_lsp.language_server_initialization_options(language_server_id, worktree)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        match language_server_id.as_ref() {
+            SomeSass::LANGUAGE_SERVER_ID => {
+                let some_sass = self.some_sass.get_or_insert_with(|| SomeSass::new());
+                some_sass.language_server_workspace_configuration(language_server_id, worktree)
+            }
+            SCSSLsp::LANGUAGE_SERVER_ID => {
+                let scss_lsp = self.scss_lsp.get_or_insert_with(|| SCSSLsp::new());
+                scss_lsp.language_server_workspace_configuration(language_server_id, worktree)
+            }
+            _ => Ok(None),
+        }
+    }
 }
 zed::register_extension!(SCSSExtension);


### PR DESCRIPTION
This allows for user-level lsp configuration via `zed/settings.json`. 

I have personally just disabled `scss-lsp` entirely, but this provides an additional workaround for #23 while keeping both enabled via
```json
"lsp": {
  "some-sass-lsp": {
    "settings": {
      "somesass": {
        "scss": {
          "completion": {
            "enabled": false
          }
        }
      }
    }
  },
  "scss-lsp": {
    "settings": {
      "scss": {
        "hover": {
          "documentation": false,
          "references": false
        }
      }
    }
  }
},
```
(It seems that it's not possible to disable scss-lsp completion)

---

In action with the above and some-sass colors enabled:

<img width="1104" height="876" alt="image" src="https://github.com/user-attachments/assets/7753deab-ab18-4cff-87dc-b76ab92478b5" />

---

Full some-sass configuration options can be found here: https://wkillerud.github.io/some-sass/user-guide/settings.html#scss
Full scss-lsp configuration options can be found here: https://code.visualstudio.com/docs/languages/css#_customizing-css-scss-and-less-settings