### PR TITLE
fix: rewrite query files for correctness, compliance, and sassdoc highlighting

### DIFF
--- a/languages/sassdoc/highlights.scm
+++ b/languages/sassdoc/highlights.scm
@@ -1,3 +1,8 @@
+; Base: paint entire document as doc comment so /// markers and all
+; uncaptured regions get a consistent doc comment color.
+; More specific patterns below will override for semantic elements.
+(document) @comment.doc
+
 ; Tag keywords
 [
   "@param"
@@ -35,7 +40,7 @@
 
 ; Access modifiers
 (tag_access
-  ["public" "private"] @keyword.modifier)
+  ["public" "private"] @keyword)
 
 ; Reference types
 (reference) @type
@@ -50,36 +55,36 @@
 (version) @number
 
 ; Description text
-(description) @comment
-(line_description) @comment
+(description) @comment.doc
+(line_description) @comment.doc
 
 ; Example language identifier
 (example_language) @label
 
-; Code blocks and lines - use @comment as fallback, injection will override with language-specific highlights
-(code_block) @comment
-(code_line) @comment
+; Code blocks and lines - use @comment.doc as fallback, injection will override with language-specific highlights
+(code_block) @comment.doc
+(code_line) @comment.doc
 
 ; See references
 (see_reference) @function
 
 ; Group names
-(group_name) @module
+(group_name) @type
 
 ; Alias names
 (alias_name) @function
 
 ; Package names
-(package_name) @module
+(package_name) @type
 
 ; Property names
 (property_name) @property
 
 ; URLs
-(url) @string.special.url
+(url) @string.special
 
 ; Link captions
-(link_caption) @comment
+(link_caption) @comment.doc
 
 ; Custom names
 (custom_name) @string

--- a/languages/scss/brackets.scm
+++ b/languages/scss/brackets.scm
@@ -1,3 +1,8 @@
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
+
+; Interpolation brackets
+(interpolation
+  "#{" @open
+  "}" @close)

--- a/languages/scss/folds.scm
+++ b/languages/scss/folds.scm
@@ -1,43 +1,62 @@
-; Fold blocks with braces
-(block) @fold
-
-; Fold rule sets
+; Rule sets
 (rule_set) @fold
 
-; Fold at-rule statements with blocks
-(media_statement) @fold
-(supports_statement) @fold
-(keyframes_statement) @fold
-(container_statement) @fold
-(layer_statement) @fold
-(scope_statement) @fold
-(starting_style_statement) @fold
-(view_transition_statement) @fold
-(font_face_statement) @fold
-(counter_style_statement) @fold
-(position_try_statement) @fold
-(font_palette_values_statement) @fold
-(page_statement) @fold
-(font_feature_values_statement) @fold
+; At-rule statements with blocks
+[
+  (media_statement)
+  (supports_statement)
+  (keyframes_statement)
+  (container_statement)
+  (layer_statement)
+  (scope_statement)
+  (starting_style_statement)
+  (view_transition_statement)
+  (font_face_statement)
+  (counter_style_statement)
+  (position_try_statement)
+  (font_palette_values_statement)
+  (page_statement)
+  (font_feature_values_statement)
+  (property_statement)
+  (at_root_statement)
+  (at_rule)
+] @fold
 
-; Fold control flow statements
-(if_statement) @fold
-(each_statement) @fold
-(for_statement) @fold
-(while_statement) @fold
+; Nested at-rule blocks
+(margin_at_rule) @fold
+(font_feature_value_block) @fold
+(keyframe_block) @fold
 
-; Fold function and mixin definitions
-(function_statement) @fold
-(mixin_statement) @fold
+; Control flow statements
+[
+  (if_statement)
+  (each_statement)
+  (for_statement)
+  (while_statement)
+] @fold
 
-; Fold placeholders
+; Function and mixin definitions
+[
+  (function_statement)
+  (mixin_statement)
+] @fold
+
+; Include statements with content blocks
+(include_statement) @fold
+
+; Placeholders
 (placeholder) @fold
 
-; Fold multi-line comments
+; Multi-line comments
 (comment) @fold
 
-; Fold sassdoc blocks
+; Sassdoc blocks
 (sassdoc_block) @fold
 
-; Fold map values (useful for large config maps)
+; Map values (useful for large config maps)
 (map_value) @fold
+
+; Consecutive import/use/forward statements
+(import_statement)+ @fold
+(use_statement)+ @fold
+(forward_statement)+ @fold

--- a/languages/scss/highlights.scm
+++ b/languages/scss/highlights.scm
@@ -1,14 +1,16 @@
 [
   (comment)
   (single_line_comment)
-  (sassdoc_block)
 ] @comment
 
+(sassdoc_block) @comment.doc
+
+(tag_name) @tag
+
 [
-  (tag_name)
   (universal_selector)
   (nesting_selector)
-] @tag
+] @character.special
 
 (attribute_selector (plain_value) @string)
 (parenthesized_query
@@ -60,16 +62,16 @@
   (unary_expression "not" @keyword.operator)
 ]
 
-(pseudo_element_selector "::" (tag_name) @selector.pseudo)
-(pseudo_class_selector ":" (class_name) @selector.pseudo)
-(page_pseudo_class) @selector.pseudo
+(pseudo_element_selector "::" (tag_name) @attribute)
+(pseudo_class_selector ":" (class_name) @attribute)
+(page_pseudo_class) @attribute
 
 [
   (variable_name)
   (variable_value)
-] @variable.other.member
+] @variable
 
-(container_statement (container_name) @variable.other.member)
+(container_statement (container_name) @variable)
 
 (argument_name) @variable.parameter
 
@@ -79,15 +81,15 @@
   (property_name)
 ] @property
 
-(id_name) @selector.id
-(class_name) @selector.class
-(placeholder_name) @selector.class
-(namespace_name) @namespace
-(namespace_selector (tag_name) @namespace "|")
-(variable_module (module) @namespace)
-(call_expression module: (module) @namespace)
+(id_name) @constant
+(class_name) @type
+(placeholder_name) @type
+(namespace_name) @module
+(namespace_selector (tag_name) @module "|")
+(variable_module (module) @module)
+(call_expression module: (module) @module)
 
-(attribute_name) @attribute
+(attribute_name) @tag.attribute
 
 [
   (function_name)
@@ -99,10 +101,11 @@
 
 [
   (plain_value)
-  (keyframes_name)
   (keyword_query)
   (feature_value)
 ] @constant.builtin
+
+(keyframes_name) @variable
 
 (interpolation "#{" @punctuation.special "}" @punctuation.special)
 
@@ -128,17 +131,22 @@
   "@debug"
   "@error"
   "@extend"
-  "@mixin"
   "@warn"
   (at_keyword)
+  (margin_at_keyword)
+  (font_feature_value_keyword)
+] @keyword.directive
+
+[
   (to)
   (from)
+] @keyword
+
+[
   (important)
   (default)
   (global)
-  (margin_at_keyword)
-  (font_feature_value_keyword)
-] @keyword
+] @keyword.modifier
 
 ; Scope bare keyword strings to their parent nodes to avoid
 ; false matches inside identifiers (e.g. "as" in "ease-out").
@@ -175,7 +183,7 @@
 
 (attr_type (keyword) @keyword)
 (syntax_type) @type
-(if_else_condition) @keyword.control.conditional
+(if_else_condition) @keyword.conditional
 
 (style_condition
   (property_name) @property)
@@ -184,15 +192,18 @@
   (state_name) @property
   (state_value) @constant.builtin)
 
-"@function" @keyword.function
+[
+  "@function"
+  "@mixin"
+] @keyword.function
 
-"@return" @keyword.control.return
+"@return" @keyword.return
 
 [
   "@else"
   "@if"
-] @keyword.control.conditional
-(else_if_clause "if" @keyword.control.conditional)
+] @keyword.conditional
+(else_if_clause "if" @keyword.conditional)
 
 ; Scope loop keywords to their parent nodes
 [
@@ -209,16 +220,21 @@
   "@import"
   "@include"
   "@use"
-] @keyword.control.import
+] @keyword.import
+
+; Custom properties (CSS variables) as @variable
+((property_name) @variable
+  (#lua-match? @variable "^[-][-]"))
+
+((plain_value) @variable
+  (#lua-match? @variable "^[-][-]"))
 
 (string_value) @string
 (color_value) @string.special
 
-[
-  (integer_value)
-  (float_value)
-] @number
-(unit) @type.unit
+(integer_value) @number
+(float_value) @number.float
+(unit) @type
 
 (boolean_value) @boolean
 (null_value) @constant.builtin

--- a/languages/scss/indents.scm
+++ b/languages/scss/indents.scm
@@ -1,7 +1,26 @@
+; CSS base indentation
 [
-  (mixin_statement)
-  (while_statement)
-  (each_statement)
+  (block)
+  (declaration)
 ] @indent.begin
 
-(_ "{" "}" @end) @indent
+(block
+  "}" @indent.branch)
+
+"}" @indent.dedent
+
+(comment) @indent.ignore
+
+; SCSS-specific indentation
+[
+  (mixin_statement)
+  (function_statement)
+  (if_clause)
+  (else_if_clause)
+  (else_clause)
+  (each_statement)
+  (for_statement)
+  (while_statement)
+  (include_statement)
+  (placeholder)
+] @indent.begin

--- a/languages/scss/injections.scm
+++ b/languages/scss/injections.scm
@@ -1,4 +1,10 @@
+; Inject comment parser for TODO/FIXME/NOTE highlighting
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((single_line_comment) @injection.content
+  (#set! injection.language "comment"))
+
 ; Inject sassdoc into documentation blocks
-; sassdoc_block groups consecutive /// comments
 ((sassdoc_block) @injection.content
   (#set! injection.language "sassdoc"))

--- a/languages/scss/outline.scm
+++ b/languages/scss/outline.scm
@@ -40,14 +40,14 @@
 (mixin_statement
     "@mixin" @context
     (name) @name
-    (_) @context.extra
+    (parameters)? @context.extra
     (block)
 ) @item
 
 (function_statement
     "@function" @context
     (name) @name
-    (parameters) @context.extra
+    (parameters)? @context.extra
 ) @item
 
 (each_statement
@@ -82,6 +82,38 @@
 (forward_statement
     "@forward" @context
     (_) @name
+) @item
+
+(include_statement
+    "@include" @context
+    (mixin_name) @name
+    (block)
+) @item
+
+(supports_statement
+    "@supports" @context
+    (_) @name
+    (block)
+) @item
+
+(at_root_statement
+    "@at-root" @context
+    (selectors
+      .
+      (_) @name
+    )
+    (block)
+) @item
+
+(property_statement
+    "@property" @context
+    (property_name) @name
+    (block)
+) @item
+
+(scope_statement
+    "@scope" @name
+    (block)
 ) @item
 
 (if_clause
@@ -139,3 +171,4 @@
 ) @item
 
 (comment) @annotation
+(sassdoc_block) @annotation


### PR DESCRIPTION
Sorry for opening another PR so soon after the my first one. I should've spent a bit more time looking at queries for Zed(and Neovim for that matter). I found some outstanding issues and I had to fix them.

This PR improves upon the queries for both Scss and SassDoc in almost all ways - highlights, blocks, folds, indents, etc.

Hopefully, things will be a lot more stable from now on.